### PR TITLE
I've added the init, navigation, upgrade, and remember features. Here…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,45 @@
 Simple prompt, simple command. Stay simple, stay naive.
 
 # Get started
-you will need your sambanova api key which can be obtained from https://cloud.sambanova.ai/apis
-## clone the repo
+
+## Clone the repo
 ```
 git clone https://github.com/wstlxx/What-The-Function.git && cd What-The-Function
 ```
-## run the installer
+## Run the installer
 ```
 chmod +x ./install.sh && ./install.sh
 ```
-## refresh the terminal
+## Configure the tool
+Run `wtf --init` to set up your API endpoint and key.
 ```
-source ~/.bashrc
+wtf --init
 ```
+This will create a configuration file at `~/.config/wtf/config.json`.
+
 ---
 # Usage
-try your command with natural language like:
+Try your command with natural language like:
 ```
 wtf whatever command you desire
 ```
+The tool will suggest a command. You can then:
+- Press `Y` to execute the command.
+- Press `N` to see the next suggestion.
+- Press `P` to see the previous suggestion.
+- Press `Q` to quit.
+
 ---
-![msedge_E0cmJr70pN](https://github.com/user-attachments/assets/bae64db5-b96c-46d9-ac84-17fc80e3007c)
+# Remember Preferences
+You can save preferences to be used in the prompt with the `-r` or `--remember` flag.
+```
+wtf -r "always use sudo for docker commands"
+```
+This will save the preference to your configuration file.
+
+---
+# Upgrade
+To upgrade `wtf` to the latest version, run:
+```
+wtf --upgrade
+```

--- a/install.sh
+++ b/install.sh
@@ -12,34 +12,10 @@ chmod +x ./wtf.py
 # Copy the script to /usr/bin/wtf (requires sudo)
 sudo cp ./wtf.py /usr/bin/wtf
 
-# Prompt the user for input
-echo "Please enter your Sambanova API key:"
-read api_key
-
-# Determine which shell configuration file to use
-if [ -n "$BASH_VERSION" ]; then
-    config_file="$HOME/.bashrc"
-elif [ -n "$ZSH_VERSION" ]; then
-    config_file="$HOME/.zshrc"
-else
-    echo "Unsupported shell. Please manually add the export command to your shell's configuration file."
-    exit 1
-fi
-
-# Add the export command to the shell configuration file
-echo "export SAMBANOVA_API_KEY=\"$api_key\"" >> "$config_file"
-
-# Set the variable for the current session
-export SAMBANOVA_API_KEY="$api_key"
-
-# Confirm the variable has been set
-echo "SAMBANOVA_API_KEY has been set to: $SAMBANOVA_API_KEY"
-echo "The export command has been added to $config_file"
-echo "Please restart your terminal or run 'source $config_file' for the change to take effect in new sessions."
-
 # Check if the copy was successful
 if [ $? -eq 0 ]; then
   echo "Successfully installed wtf script to /usr/bin/wtf."
+  echo "Please run 'wtf --init' to configure the API endpoint and key."
 else
   echo "Error: Failed to copy wtf script to /usr/bin/wtf."
 fi


### PR DESCRIPTION
… are the changes I made:

- Added a `wtf --init` command to let you configure your API endpoint and key.
- Changed the default endpoint to OpenRouter and added command navigation.
- Added a `wtf --upgrade` command so you can update the script.
- Added a `wtf -r` option to remember your preferences.
- Updated the documentation and installation script.