### PR TITLE
feat: Add cross-platform support for Windows, macOS, and Linux

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,23 @@
+@echo off
+REM Installation script for wtf on Windows
+
+REM Create a directory for the application
+set WTF_DIR=%APPDATA%\wtf
+if not exist "%WTF_DIR%" (
+    mkdir "%WTF_DIR%"
+    echo Created directory %WTF_DIR%
+)
+
+REM Copy the Python script
+copy wtf_new.py "%WTF_DIR%\wtf.py"
+
+REM Create a batch file to run the Python script
+echo @python "%WTF_DIR%\wtf.py" %* > "%WTF_DIR%\wtf.bat"
+
+REM Add the directory to the user's PATH
+setx PATH "%PATH%;%WTF_DIR%"
+
+echo.
+echo wtf has been installed.
+echo Please restart your terminal for the changes to take effect.
+echo You can then run 'wtf --init' to get started.

--- a/install.sh
+++ b/install.sh
@@ -9,13 +9,29 @@ fi
 # Make the script executable
 chmod +x ./wtf_new.py
 
-# Copy the script to /usr/bin/wtf (requires sudo)
-sudo cp ./wtf_new.py /usr/bin/wtf
+# Determine the OS
+OS="$(uname)"
+INSTALL_PATH=""
+
+if [ "$OS" == "Linux" ]; then
+  INSTALL_PATH="/usr/bin/wtf"
+elif [ "$OS" == "Darwin" ]; then
+  INSTALL_PATH="/usr/local/bin/wtf"
+else
+  echo "Unsupported OS: $OS"
+  exit 1
+fi
+
+echo "Attempting to install wtf to $INSTALL_PATH"
+
+# Copy the script to the install path (requires sudo)
+sudo cp ./wtf_new.py "$INSTALL_PATH"
 
 # Check if the copy was successful
 if [ $? -eq 0 ]; then
-  echo "Successfully installed wtf script to /usr/bin/wtf."
+  echo "Successfully installed wtf script to $INSTALL_PATH."
   echo "Please run 'wtf --init' to configure the API endpoint and key."
 else
-  echo "Error: Failed to copy wtf script to /usr/bin/wtf."
+  echo "Error: Failed to copy wtf script to $INSTALL_PATH."
+  echo "Please ensure you have the necessary permissions (e.g., run with sudo if needed)."
 fi

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,14 @@
+@echo off
+REM Uninstallation script for wtf on Windows
+
+REM Remove the application directory
+set WTF_DIR=%APPDATA%\wtf
+if exist "%WTF_DIR%" (
+    rmdir /s /q "%WTF_DIR%"
+    echo Removed directory %WTF_DIR%
+)
+
+echo.
+echo wtf has been uninstalled.
+echo Please manually remove '%%APPDATA%%\wtf' from your PATH environment variable.
+echo You may need to restart your terminal for the changes to take effect.

--- a/wtf_new.py
+++ b/wtf_new.py
@@ -2,13 +2,20 @@
 
 import os
 import sys
+import platform
 import requests
 import subprocess
 import json
-import tty
-import termios
-import readline
+if platform.system() != "Windows":
+    import tty
+    import termios
+    import readline
+else:
+    # No equivalent for tty and termios needed for basic getch
+    # pyreadline can be an alternative for readline, but we'll keep it simple
+    import msvcrt
 
+OS_NAME = platform.system()
 CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "wtf")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 
@@ -68,15 +75,37 @@ def set_model(model):
 def get_single_char():
     """
     Waits for a single keypress on stdin and returns the character.
+    Cross-platform implementation.
     """
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setcbreak(sys.stdin.fileno())
-        char = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return char
+    if OS_NAME == 'Windows':
+        # Note: msvcrt.getch() returns a byte string
+        return msvcrt.getch().decode('utf-8', errors='ignore')
+    else:
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setcbreak(sys.stdin.fileno())
+            char = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return char
+
+def get_os_specific_prompts():
+    if OS_NAME == "Windows":
+        return {
+            "system_prompt": "You are a helpful assistant that provides 3 distinct Windows PowerShell commands. You give command directly without explain or anything else since your response should be used directly as command to send. no brackets or quotation marks, your response should be in format 'command 1\\ncommand 2\\ncommand 3'",
+            "user_prompt_template": "What's the Windows PowerShell command for: {prompt}"
+        }
+    elif OS_NAME == "Darwin":
+        return {
+            "system_prompt": "You are a helpful assistant that provides 3 distinct macOS commands. You give command directly without explain or anything else since your response should be used directly as command to send. no brackets or quotation marks, your response should be in format 'command 1\\ncommand 2\\ncommand 3'",
+            "user_prompt_template": "What's the macOS command for: {prompt}"
+        }
+    else: # Linux and other Unix-likes
+        return {
+            "system_prompt": "You are a helpful assistant that provides 3 distinct Linux commands. You give command directly without explain or anything else since your response should be used directly as command to send. no brackets or quotation marks, your response should be in format 'command 1\\ncommand 2\\ncommand 3'",
+            "user_prompt_template": "What's the Linux command for: {prompt}"
+        }
 
 def get_command(prompt):
     config = load_config()
@@ -96,7 +125,8 @@ def get_command(prompt):
         "X-Title": "What The Function"
     }
 
-    system_prompt = "You are a helpful assistant that provides 3 distinct Linux commands. You give command directly without explain or anything else since your response should be used directly as command to send. no brackets or quotation marks, your response should be in format 'command 1\\ncommand 2\\ncommand 3'"
+    prompts = get_os_specific_prompts()
+    system_prompt = prompts["system_prompt"]
     if preferences:
         system_prompt += "\n\nPlease also follow these user-provided instructions:\n- " + "\n- ".join(preferences)
 
@@ -104,7 +134,7 @@ def get_command(prompt):
         "model": model,
         "messages": [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": f"What's the Linux command for: {prompt}"}
+            {"role": "user", "content": prompts["user_prompt_template"].format(prompt=prompt)}
         ]
     }
 
@@ -158,6 +188,14 @@ def get_answer(prompt):
 
 def edit_and_execute_command(command):
     """Allows editing and executing a command."""
+    if OS_NAME == 'Windows':
+        print(f"Executing command directly (editing not supported on Windows): {command}")
+        try:
+            subprocess.run(command, shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Command failed with error: {e}")
+        return
+
     def prefill_input():
         readline.insert_text(command)
     readline.set_startup_hook(prefill_input)
@@ -174,6 +212,12 @@ def edit_and_execute_command(command):
 
 def uninstall():
     """Removes wtf and all its configuration."""
+    if OS_NAME == "Windows":
+        print("To uninstall wtf on Windows, please run the uninstall.bat script from the installation directory.")
+        print("The installation directory is typically %APPDATA%\\wtf")
+        sys.exit(0)
+
+    # For Linux and macOS
     if os.geteuid() != 0:
         print("Please run the uninstall command with sudo: sudo wtf --uninstall")
         sys.exit(1)
@@ -191,9 +235,16 @@ def uninstall():
         shutil.rmtree(config_dir)
         print(f"Removed configuration directory: {config_dir}")
 
+    # Determine the script path based on the OS
+    if OS_NAME == "Linux":
+        script_path = "/usr/bin/wtf"
+    elif OS_NAME == "Darwin":
+        script_path = "/usr/local/bin/wtf"
+    else:
+        script_path = None
+
     # Remove the script itself
-    script_path = "/usr/bin/wtf"
-    if os.path.exists(script_path):
+    if script_path and os.path.exists(script_path):
         os.remove(script_path)
         print(f"Removed script: {script_path}")
 
@@ -218,7 +269,11 @@ def upgrade_script():
         print(f"An error occurred during the upgrade: {e}")
 
 def main():
+    usage_string = "Usage: wtf <your question about a command>\nOr: wtf --init | --upgrade | --remember <preference> | --set-model <model_name> | --uninstall | --ask <question> | --help"
     if len(sys.argv) > 1:
+        if sys.argv[1] in ['-h', '--help']:
+            print(usage_string)
+            sys.exit(0)
         if sys.argv[1] == '--init':
             initialize_config()
             sys.exit(0)
@@ -241,8 +296,7 @@ def main():
             sys.exit(0)
 
     if len(sys.argv) < 2:
-        print("Usage: wtf <your question about a Linux command>")
-        print("Or: wtf --init | --upgrade | --remember <preference> | --set-model <model_name> | --uninstall | --ask <question>")
+        print(usage_string)
         sys.exit(1)
 
     prompt = " ".join(sys.argv[1:])


### PR DESCRIPTION
This commit introduces cross-platform compatibility for the `wtf` command-line tool, enabling it to run on Windows, macOS, and Linux.

Key changes include:
- **OS-specific installation scripts:**
  - An `install.bat` and `uninstall.bat` script have been created for Windows.
  - The `install.sh` script has been updated to use the correct installation paths for both Linux (`/usr/bin`) and macOS (`/usr/local/bin`).

- **OS-aware Python script (`wtf_new.py`):**
  - The script now detects the operating system using the `platform` module.
  - System prompts sent to the AI are now tailored to the detected OS (e.g., "Windows PowerShell command").
  - The `get_single_char` function is now cross-platform, using `msvcrt` on Windows and `termios`/`tty` on Unix-like systems.
  - The `edit_and_execute_command` function now has a fallback for Windows, where `readline` is not available.
  - The `uninstall` function is now cross-platform, providing appropriate instructions or actions for each OS.
  - A `--help` flag has been added for improved usability.