### PR TITLE
fix(install): Use 'reg' command to set PATH on Windows

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,6 @@
 @echo off
+setlocal enabledelayedexpansion
+
 REM Installation script for wtf on Windows
 
 set WTF_DIR=%APPDATA%\wtf
@@ -7,7 +9,7 @@ if not exist "%WTF_DIR%" (
     echo Created directory %WTF_DIR%
 )
 
-copy wtf_new.py "%WTF_DIR%\wtf.py"
+copy wtf_new.py "%WTF_DIR%\wtf.py" > nul
 
 (
   echo @echo off
@@ -18,7 +20,37 @@ copy wtf_new.py "%WTF_DIR%\wtf.py"
   echo python "$PSScriptRoot\wtf.py" $args
 ) > "%WTF_DIR%\wtf.ps1"
 
-setx PATH "%PATH%;%WTF_DIR%"
+
+echo Adding %WTF_DIR% to the user PATH.
+
+set REG_KEY="HKEY_CURRENT_USER\Environment"
+set REG_VALUE="PATH"
+
+REM Get the current PATH value
+for /f "tokens=2*" %%a in ('reg query %REG_KEY% /v %REG_VALUE% 2^>nul') do (
+    set CurrentPath=%%b
+)
+
+REM Check if the path is already there
+echo ";!CurrentPath!;" | find /I ";%WTF_DIR%;" >nul
+if %errorlevel%==0 (
+    echo %WTF_DIR% is already in your PATH.
+) else (
+    echo Appending %WTF_DIR% to your PATH.
+    REM If CurrentPath is empty, we set it. Otherwise, we append.
+    if defined CurrentPath (
+        set "NewPath=!CurrentPath!;%WTF_DIR%"
+    ) else (
+        set "NewPath=%WTF_DIR%"
+    )
+    reg add %REG_KEY% /v %REG_VALUE% /t REG_EXPAND_SZ /d "!NewPath!" /f > nul
+    if !errorlevel! == 0 (
+        echo Successfully added %WTF_DIR% to your PATH.
+    ) else (
+        echo Failed to add %WTF_DIR% to your PATH. Please do it manually.
+    )
+)
+
 
 echo.
 echo wtf has been installed.
@@ -26,3 +58,5 @@ echo 'wtf.bat' and 'wtf.ps1' have been created in %WTF_DIR%
 echo For PowerShell users, 'wtf.ps1' is recommended.
 echo Please restart your terminal for the changes to take effect.
 echo You can then run 'wtf --init' to get started.
+
+endlocal


### PR DESCRIPTION
This commit fixes a bug in the Windows installation script (`install.bat`) where adding the application directory to the PATH would fail if the user's existing PATH was longer than 1024 characters.

The `setx` command, which has this limitation, has been replaced with a more robust method that uses the `reg` command to modify the PATH environment variable directly in the Windows Registry.

The new implementation in `install.bat`:
- Queries the current user PATH from the registry.
- Checks if the application directory is already present to avoid duplicates.
- Appends the new directory to the PATH.
- Handles the edge case where the PATH variable may not exist.
- Uses best practices for batch scripting, such as `setlocal` and delayed expansion, for safe and reliable execution.